### PR TITLE
fix: improve icon alignment with translate 

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -309,9 +309,9 @@ function injectStyles() {
       margin-right: var(--orca-spacing-md);
       cursor: pointer;
       font-size: calc(.25rem + var(--orca-block-line-height) / var(--orca-lineheight-md));
-      display: block;
-      float:left;
-      line-height: var(--orca-block-line-height);
+      display: inline-block;
+      line-height: 1;
+      translate: 0 .125rem;
     }
 
     .orca-repr-main-content:has(>.orca-tags>.orca-tag[data-name="${taskTagName}"][data-${statusPropName}="${statusTodoValue}"])::before,


### PR DESCRIPTION
原先float的对齐方式，第二行开头有时会被挤开。因此恢复为translate对齐。